### PR TITLE
Remove duplicate Timer import

### DIFF
--- a/algorithms/RAFT_GossipFL/main.py
+++ b/algorithms/RAFT_GossipFL/main.py
@@ -16,7 +16,6 @@ from algorithms.RAFT_GossipFL.raft_worker_manager import RaftWorkerManager
 
 from utils.timer import Timer
 from utils.metrics import Metrics
-from utils.timer_with_cuda import Timer
 
 def add_args(parser):
     """


### PR DESCRIPTION
## Summary
- remove duplicate Timer import in RAFT_GossipFL main script

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685f8b885e1c8321aa1da37199b14345