### PR TITLE
Improve RaftConsensus thread recovery

### DIFF
--- a/algorithms/RAFT_GossipFL/README.md
+++ b/algorithms/RAFT_GossipFL/README.md
@@ -69,6 +69,7 @@ RAFT-specific parameters:
 3. **Replication Thread**: Replicates log entries to followers (leader only).
 4. **Training Thread**: Handles local training and model exchange.
 5. **Coordinator Thread**: Manages round coordination (leader only).
+6. **Supervisor Thread**: Monitors worker threads and restarts them if they fail.
 
 ### Log Entry Types
 


### PR DESCRIPTION
## Summary
- add a supervisor thread for `RaftConsensus`
- move restart logic from worker threads to the supervisor
- clean up exception handlers and remove FIXME notes
- document the new supervisor thread in README

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/raft_consensus.py`
- `find algorithms/RAFT_GossipFL -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_685f8be105c88321854a5a609652aa49