### PR TITLE
Fix timer import

### DIFF
--- a/algorithms/RAFT_GossipFL/main.py
+++ b/algorithms/RAFT_GossipFL/main.py
@@ -14,9 +14,8 @@ from algorithms.RAFT_GossipFL.raft_topology_manager import RaftTopologyManager
 from algorithms.RAFT_GossipFL.raft_bandwidth_manager import RaftBandwidthManager
 from algorithms.RAFT_GossipFL.raft_worker_manager import RaftWorkerManager
 
-from utils.timer import Timer
 from utils.metrics import Metrics
-from utils.timer_with_cuda import Timer
+from utils.timer_with_cuda import Timer as CUDATimer
 
 def add_args(parser):
     """
@@ -55,9 +54,9 @@ def init_processes(args, rank, size):
     
     # Initialize topology and bandwidth managers
     if args.timing:
-        timer = Timer()
+        timer = CUDATimer()
     else:
-        timer = Timer()
+        timer = CUDATimer()
     
     # Create the metrics object
     metrics = Metrics([])


### PR DESCRIPTION
## Summary
- alias the CUDA timer in RAFT main so the CPU version isn't imported

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685f8bfc43a883218494c69cd6414615