### PR TITLE
Add topology update helpers for RAFT

### DIFF
--- a/algorithms/RAFT_GossipFL/raft_node.py
+++ b/algorithms/RAFT_GossipFL/raft_node.py
@@ -412,7 +412,7 @@ class RaftNode:
             if match is not None:
                 self.topology_manager.update_match(match, round_num)
             if topology_matrix is not None:
-                self.topology_manager.update_topology_matrix(topology_matrix)
+                self.topology_manager.update_topology_matrix(topology_matrix, round_num)
         else:
             # Store the topology information for later use
             if not hasattr(self, 'pending_topology'):

--- a/algorithms/RAFT_GossipFL/raft_worker_manager.py
+++ b/algorithms/RAFT_GossipFL/raft_worker_manager.py
@@ -707,10 +707,8 @@ class RaftWorkerManager(DecentralizedWorkerManager):
             if topology_data is not None:
                 topology = np.array(topology_data)
                 round_num = state_package.get('current_round', 0)
-                self.topology_manager.apply_topology_update({
-                    'round': round_num,
-                    'matrix': topology
-                })
+                # Update topology manager directly using the provided matrix
+                self.topology_manager.update_topology_matrix(topology, round_num)
                 logging.info("Applied topology from state snapshot")
             
             # Update bandwidth if available


### PR DESCRIPTION
## Summary
- track match list and topology matrix in `RaftTopologyManager`
- expose helper methods `update_match`, `update_topology_matrix`, `apply_match_changes` and `get_topology`
- use the new helpers from `RaftNode` and `RaftWorkerManager`

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/raft_topology_manager.py algorithms/RAFT_GossipFL/raft_worker_manager.py algorithms/RAFT_GossipFL/raft_node.py`

------
https://chatgpt.com/codex/tasks/task_e_685f9116324c832191d47d635df13d78