### PR TITLE
Add RAFT local run script and fix manager helpers

### DIFF
--- a/algorithms/RAFT_GossipFL/raft_worker_manager.py
+++ b/algorithms/RAFT_GossipFL/raft_worker_manager.py
@@ -950,3 +950,18 @@ class RaftWorkerManager(DecentralizedWorkerManager):
             if self.is_coordinator:
                 self.propose_topology_update(force_regenerate=True)
 
+    def refresh_gossip_info(self):
+        """Refresh local gossip information from the topology manager."""
+        self.neighbors_info = self.topology_manager.topology
+        self.gossip_info = self.topology_manager.topology[self.worker_index]
+
+    def lr_schedule(self, epoch, iteration, round_idx, num_iterations, warmup_epochs):
+        """Delegate learning rate scheduling to the parent implementation."""
+        super().lr_schedule(epoch, iteration, round_idx, num_iterations, warmup_epochs)
+
+    def send_notify_to_coordinator(self, receive_id=None, train_metric_info=None, test_metric_info=None):
+        """Send a notification to the current RAFT leader."""
+        if receive_id is None:
+            receive_id = self.coordinator_id if self.coordinator_id is not None else 0
+        super().send_notify_to_coordinator(receive_id, train_metric_info, test_metric_info)
+

--- a/experiments/mpi_based/run_raft_localhost.sh
+++ b/experiments/mpi_based/run_raft_localhost.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# export entity=""  # Disable wandb by leaving empty
+export entity="jv-fuisl-vietnamese-german-university"  # Your actual wandb entity
+export project="gossipfl"
+
+export cluster_name="localhost"
+
+# Override the default mappings for single GPU with 4 workers
+export GOSSIP_MPI_HOST="localhost:4"
+export GOSSIP_GPU_MAPPINGS="localhost:4"
+
+export NWORKERS=4
+
+# Dataset and model configuration
+export dataset="cifar10"
+export model="cifar10flnet"
+
+# Training configuration
+export sched="StepLR"
+export lr_decay_rate=0.992
+export partition_method='hetero'
+export partition_alpha=0.5
+export lr=0.04
+
+# Launch RAFT_GossipFL experiment
+echo "Launching RAFT_GossipFL experiment with 4 workers on single GPU"
+echo "Dataset: $dataset, Model: $model"
+echo "Learning rate: $lr, Partition: $partition_method (alpha=$partition_alpha)"
+
+lr=$lr algorithm="RAFT_GossipFL" bash ./launch_mpi_based.sh


### PR DESCRIPTION
## Summary
- add `run_raft_localhost.sh` for simple RAFT_GossipFL tests
- hook RAFT worker manager into parent helpers

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/raft_worker_manager.py`
- `bash -n experiments/mpi_based/run_raft_localhost.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860bc49bec8832194118b3f96177685