### PR TITLE
Implement PreVote handling

### DIFF
--- a/algorithms/RAFT_GossipFL/raft_consensus.py
+++ b/algorithms/RAFT_GossipFL/raft_consensus.py
@@ -501,6 +501,16 @@ class RaftConsensus:
         # Send response back to the candidate
         self.worker_manager.send_vote_response(
             candidate_id, current_term, vote_granted)
+
+    def handle_prevote_request(self, candidate_id, term, last_log_index, last_log_term):
+        """Handle a PreVote request from a potential candidate."""
+        current_term, prevote_granted = self.raft_node.receive_prevote_request(
+            candidate_id, term, last_log_index, last_log_term
+        )
+
+        self.worker_manager.send_prevote_response(
+            candidate_id, current_term, prevote_granted
+        )
     
     def handle_vote_response(self, voter_id, term, vote_granted):
         """


### PR DESCRIPTION
## Summary
- implement `handle_prevote_request` in `raft_consensus`
- keep forwarding PreVote requests via `raft_worker_manager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ptflops')*

------
https://chatgpt.com/codex/tasks/task_e_6861a41d3a8483219b0c52e84b3dc3fa