### PR TITLE
Add RAFT install snapshot message support

### DIFF
--- a/algorithms/RAFT_GossipFL/raft_consensus.py
+++ b/algorithms/RAFT_GossipFL/raft_consensus.py
@@ -470,11 +470,14 @@ class RaftConsensus:
     def _send_snapshot(self, node_id):
         """Send a snapshot of the current state to the given follower."""
         try:
-            self.worker_manager.send_state_snapshot(
+            self.worker_manager.send_install_snapshot(
                 node_id,
                 self.raft_node.current_term,
+                self.raft_node.last_snapshot_index,
+                self.raft_node.last_snapshot_term,
+                0,
                 self.raft_node.log,
-                self.raft_node.commit_index,
+                True,
             )
             logging.debug(
                 f"Node {self.raft_node.node_id}: Sent snapshot to follower {node_id}"

--- a/algorithms/RAFT_GossipFL/raft_messages.py
+++ b/algorithms/RAFT_GossipFL/raft_messages.py
@@ -15,6 +15,7 @@ class RaftMessage:
     MSG_TYPE_RAFT_LEADER_REDIRECT = 109
     MSG_TYPE_RAFT_PREVOTE_REQUEST = 110
     MSG_TYPE_RAFT_PREVOTE_RESPONSE = 111
+    MSG_TYPE_RAFT_INSTALL_SNAPSHOT = 112
     
     # Message arguments
     MSG_ARG_KEY_TYPE = "msg_type"
@@ -35,6 +36,13 @@ class RaftMessage:
     MSG_ARG_MATCH_INDEX = "match_index"
     MSG_ARG_LOG = "log"
     MSG_ARG_COMMIT_INDEX = "commit_index"
+
+    # Install snapshot arguments
+    MSG_ARG_LAST_INCLUDED_INDEX = "last_included_index"
+    MSG_ARG_LAST_INCLUDED_TERM = "last_included_term"
+    MSG_ARG_OFFSET = "offset"
+    MSG_ARG_DATA = "data"
+    MSG_ARG_DONE = "done"
 
     # Initialization / parameter exchange
     MSG_ARG_MODEL_PARAMS = "model_params"


### PR DESCRIPTION
## Summary
- define MSG_TYPE_RAFT_INSTALL_SNAPSHOT and related args
- add install snapshot send/receive support in `RaftWorkerManager`
- modify consensus snapshot sending to use InstallSnapshot

## Testing
- `python -m py_compile algorithms/RAFT_GossipFL/raft_worker_manager.py algorithms/RAFT_GossipFL/raft_consensus.py algorithms/RAFT_GossipFL/raft_messages.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ptflops')*

------
https://chatgpt.com/codex/tasks/task_e_6861a444a5d48321884b77bc27a0710d